### PR TITLE
Fix compiler for stack machine

### DIFF
--- a/frap_book.tex
+++ b/frap_book.tex
@@ -595,7 +595,7 @@ Here is the compiler that concerns us now, where we write $\concat{s_1}{s_2}$ fo
 \encoding
 \begin{eqnarray*}
   \compile{n} &=& \mathsf{PushConst}(n) \\
-  \compile{x} &=& \mathsf{PushVar}(n) \\
+  \compile{x} &=& \mathsf{PushVar}(x) \\
   \compile{e_1 + e_2} &=& \concat{\compile{e_1}}{\concat{\compile{e_2}}{\mathsf{Add}}} \\
   \compile{e_1 \times e_2} &=& \concat{\compile{e_1}}{\concat{\compile{e_2}}{\mathsf{Multiply}}}
 \end{eqnarray*}


### PR DESCRIPTION
I think there's a typo for stack machine compiler - PushVar should push x not n.
