### PR TITLE
11.1: s/smallstep/smallstepo/ to match Coq source

### DIFF
--- a/frap_book.tex
+++ b/frap_book.tex
@@ -2954,13 +2954,13 @@ $$\begin{array}{rrcl}
 
 \newcommand{\dom}[1]{\mathsf{dom}(#1)}
 Now we can write the rules for the three reference primitives.
-$$\infer{\smallstep{(h, \newref{v})}{(\mupd{h}{\ell}{v}, \ell)}}{
+$$\infer{\smallstepo{(h, \newref{v})}{(\mupd{h}{\ell}{v}, \ell)}}{
   \ell \notin \dom{h}
 }
-\quad \infer{\smallstep{(h, \readref{\ell})}{(h, v)}}{
+\quad \infer{\smallstepo{(h, \readref{\ell})}{(h, v)}}{
   \msel{h}{\ell} = v
 }
-\quad \infer{\smallstep{(h, \writeref{\ell}{v'})}{(\mupd{h}{\ell}{v'}, v')}}{
+\quad \infer{\smallstepo{(h, \writeref{\ell}{v'})}{(\mupd{h}{\ell}{v'}, v')}}{
   \msel{h}{\ell} = v
 }$$
 


### PR DESCRIPTION
https://github.com/achlipala/frap/blob/master/TypesAndMutation.v#L117 allows new/read/overwrite inside contexts, but in the book the corresponding arrows were missing _0.