### PR TITLE
Update frap_book.tex

### DIFF
--- a/frap_book.tex
+++ b/frap_book.tex
@@ -1017,7 +1017,7 @@ Actually, the words ``state machine'' suggest to many people that the state set 
 \end{definition}
 
 For an arbitrary transition relation $\to$, not just the one defined above for factorial, we define its \emph{transitive-reflexive closure}\index{transitive-reflexive closure} $\to^*$ with two inference rules:
-$$\infer{s \to^* s}{}
+$$\infer{s \to^* s'}{}
 \quad \infer{s \to^* s''}{
   s \to s'
   & s' \to^* s''


### PR DESCRIPTION
Typo? Otherwise \infer{ s \to^* s } would assume an identity closure which afaik is not necessary. If it is necessary for transition systems to have an identity closure, then maybe some explanation would be useful.