### PR TITLE
Fix typo in book with label for Embeddings chapter

### DIFF
--- a/frap_book.tex
+++ b/frap_book.tex
@@ -3453,7 +3453,8 @@ In fact, we can prove that any other state is unstuck, though we won't bother he
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\chapter{label{embeddings}Deep Embeddings, Shallow Embeddings, and Options in Between}
+\chapter{Deep Embeddings, Shallow Embeddings, and Options in Between}
+\label{embeddings}
 
 So far, in this book, we have followed the typographic conventions of ordinary mathematics and logic, as they would be worked out on whiteboards.
 In parallel, we have mechanized all of the definitions and proofs in Coq.


### PR DESCRIPTION
A typo in setting the label for the Embeddings chapter gave the Embeddings chapter a funny title (and presumably, broken links pointing to it). I just fixed the typo.