### PR TITLE
Add TransitionSystems.vo to 'lib' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ coq: Makefile.coq
 	$(MAKE) -f Makefile.coq
 
 lib: Makefile.coq
-	$(MAKE) -f Makefile.coq Frap.vo AbstractInterpret.vo SepCancel.vo
+	$(MAKE) -f Makefile.coq Frap.vo AbstractInterpret.vo SepCancel.vo TransitionSystems.vo
 
 Makefile.coq: Makefile _CoqProject *.v
 	coq_makefile -f _CoqProject -o Makefile.coq


### PR DESCRIPTION
ModelChecking.v imports the TransitionSystems module. This currently fails with:
"Unable to locate library TransitionSystems. (While searching for .vos file)"

Adding TransitionSystems.vo to the 'lib' target ensures that ModelChecking.v's imports resolve