### PR TITLE
Add missing "O - O = E" abstraction case

### DIFF
--- a/frap_book.tex
+++ b/frap_book.tex
@@ -1984,6 +1984,7 @@ As an example, consider this formalization of even-odd analysis, whose proof of 
   \O \; \hat{+} \; \O &=& \E \\
   \_ \; \hat{+} \; \_ &=& \top \\
   \E \; \hat{-} \; \E &=& \E \\
+  \O \; \hat{-} \; \O &=& \E \\
   \_ \; \hat{-} \; \_ &=& \top \\
   \E \; \hat{\times} \; \_ &=& \E \\
   \_ \; \hat{\times} \; \E &=& \E \\


### PR DESCRIPTION
This case is implemented by parity_subtract in
AbstractInterpretation.v and is necessary to calculate the "most
precise abstraction."

See also #28, #37.