### PR TITLE
Add missing parentheses in SepCancel's normalize2 tactic

### DIFF
--- a/SepCancel.v
+++ b/SepCancel.v
@@ -252,7 +252,7 @@ Module Make(Import S : SEP).
   
   Ltac normalize2 :=
     match goal with
-    | [ |- context[star ?p lift (?P /\ ?Q)] ] => rewrite (lift_uncombine p P Q)
+    | [ |- context[star ?p (lift (?P /\ ?Q))] ] => rewrite (lift_uncombine p P Q)
     | [ |- context[star ?p (star ?q ?r)] ] => rewrite (star_assoc p q r)
     end.
 


### PR DESCRIPTION
Before this change, "Print normalize2" prints:

    Ltac Frap.SepCancel.Make.normalize2 :=
      match goal with
      | |- context [ (?p * lift) (?P /\ ?Q) ] => rewrite (lift_uncombine p P Q)
      | |- context [ ?p * (?q * ?r) ] => rewrite (star_assoc p q r)
      end

After, it prints:

    Ltac Frap.SepCancel.Make.normalize2 :=
      match goal with
      | |- context [ ?p * [|?P /\ ?Q|] ] => rewrite (lift_uncombine p P Q)
      | |- context [ ?p * (?q * ?r) ] => rewrite (star_assoc p q r)
      end