### PR TITLE
Change precedence of map includes operator according to spring 21 TODO

### DIFF
--- a/Map.v
+++ b/Map.v
@@ -20,7 +20,7 @@ Module Type S.
   Infix "$-" := remove (at level 50, left associativity).
   Infix "$++" := join (at level 50, left associativity).
   Infix "$?" := lookup (at level 50, no associativity).
-  Infix "$<=" := includes (at level 90).
+  Infix "$<=" := includes (at level 75).
 
   Parameter dom : forall A B, fmap A B -> set A.
 


### PR DESCRIPTION
Increase the precedence of includes operator so `a $<= b /\ P)` is the same as `(a $<= b) /\ P` according to TODOs